### PR TITLE
Convert unit tests memory usage to kb/mb/gb/tb/pt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "n0nag0n/fatfree-devtools",
+    "name": "germain-italic/fatfree-devtools",
     "description": "A set of tools for help in creating models, controllers, routes, etc.",
     "type": "library",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "germain-italic/fatfree-devtools",
+    "name": "n0nag0n/fatfree-devtools",
     "description": "A set of tools for help in creating models, controllers, routes, etc.",
     "type": "library",
     "license": "MIT",

--- a/templates/unit-test.php
+++ b/templates/unit-test.php
@@ -21,8 +21,14 @@ function echoLine(string $text) {
 	$dateObj = DateTime::createFromFormat('0.u00 U', microtime());
 	$dateObj->setTimeZone(new DateTimeZone('America/Denver'));
 	if($text) {
-		echo '[ '.$dateObj->format('Y-m-d H:i:s.v').' Mem: '.memory_get_usage().' ]: '.$text."\n";
+		echo '[ '.$dateObj->format('Y-m-d H:i:s.v').' Mem: '.convertMemoryUsage(memory_get_usage()).' ]: '.$text."\n";
 	}
+}
+
+// https://www.php.net/manual/fr/function.memory-get-usage.php#96280
+function convertMemoryUsage($size) {
+    $unit=array('b','kb','mb','gb','tb','pb');
+    return @round($size/pow(1024,($i=floor(log($size,1024)))),2).' '.$unit[$i];
 }
 
 function formatTextColor($str, $color) {


### PR DESCRIPTION
This PR will output the unit tests memory usage in human-friendly units instead of bytes.

![image](https://user-images.githubusercontent.com/17506424/139567651-f9f0313d-fb51-44ae-9081-53df6955b3ce.png)
