### PR TITLE
Fixed class name / file name consistency

### DIFF
--- a/config/webtools_config.ini
+++ b/config/webtools_config.ini
@@ -10,7 +10,7 @@ PROJECT_CONFIG = {{ @PROJECT_DATA_DIR.'project_config' }}
 CACHE = false
 
 [routes]
-GET / = n0nag0n\Root_Controller->index
+GET / = n0nag0n\Index_Controller->index
 GET /init-environment = n0nag0n\Init_Environment_Controller->indexAction
 GET /init-environment/build = n0nag0n\Init_Environment_Controller->build
 GET /init-environment/@page = n0nag0n\Init_Environment_Controller->pageAction

--- a/controllers/Index_Controller.php
+++ b/controllers/Index_Controller.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace n0nag0n;
 
-class Root_Controller extends Base_Controller {
+class Index_Controller extends Base_Controller {
 
 	public function index(\Base $fw): void {
 		


### PR DESCRIPTION
Note: on the dev installation you need to fix composer to autoload the new class.

I did it manually, but you might know a better way.

Here:

```
vendor/composer/autoload_classmap.php
vendor/composer/autoload_static.php
```