### PR TITLE
Bugfix: `layout.htm` — check if the config option is passed

### DIFF
--- a/ui/layout.htm
+++ b/ui/layout.htm
@@ -36,7 +36,7 @@
 						<a class="nav-link" href="/config-check">Config Check</a>
 					</li>
 					<li class="nav-item">
-						<a class="nav-link" href="{{ @config.database_management ?: '/adminer/' }}" target="_blank">Adminer</a>
+						<a class="nav-link" href="{{ isset(@config.database_management) && @config.database_management ?: '/adminer/' }}" target="_blank">Database</a>
 					</li>
 					<li class="nav-item">
 						<a class="nav-link" href="/manage-composer" target="_blank">Manage Composer</a>


### PR DESCRIPTION
There's an error on the fresh installation, since it doesn't provide the config option for the alternative database management tool (obviously).

![изображение](https://user-images.githubusercontent.com/31481176/208288490-316f3085-19e9-45c3-8829-2ce6ad1f257a.png)

Also, I changed the link text to `Database`, since the new config option allows using of any tool, not only Adminer.